### PR TITLE
Change scratch org name in project definition.

### DIFF
--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,5 +1,5 @@
 {
-  "orgName": "Demo company",
+  "orgName": "Salesforce Library Management System",
   "edition": "Developer",
   "features": [],
   "settings": {


### PR DESCRIPTION
This change will set the scratch org's name to "Salesforce Library Management System" when it is created from the project. This will make the scratch org easier to recognize when looking at active scratch orgs from the dev hub.