### PR TITLE
User trigger deletes librarian contacts.

### DIFF
--- a/force-app/main/default/classes/LibrarianContactDeleterQueueable.cls
+++ b/force-app/main/default/classes/LibrarianContactDeleterQueueable.cls
@@ -1,0 +1,22 @@
+public with sharing class LibrarianContactDeleterQueueable implements Queueable {
+    private List<User> users;
+    
+    public LibrarianContactDeleterQueueable(List<User> users) {
+        this.users = users;
+    }
+
+    public void execute(QueueableContext context) {
+        RecordType librarianRecordType = [SELECT Id FROM RecordType WHERE SobjectType='Contact' AND Name='Librarian'];
+        List<Contact> libContacts = [SELECT Id,Librarian_User__c FROM Contact WHERE RecordTypeId = :librarianRecordType.Id];
+        Map<Id,Contact> librarians = new Map<Id, Contact>();
+        for (Contact c : libContacts) librarians.put(c.Librarian_User__c, c);
+        List<Contact> contactsToDelete = new List<Contact>();
+
+        for (User u : users) {
+            if (librarians.containsKey(u.Id)) {
+                contactsToDelete.add(librarians.get(u.Id));
+            }
+        }
+        delete contactsToDelete;
+    }
+}

--- a/force-app/main/default/classes/LibrarianContactDeleterQueueable.cls-meta.xml
+++ b/force-app/main/default/classes/LibrarianContactDeleterQueueable.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>51.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/UserTriggerActions.cls
+++ b/force-app/main/default/classes/UserTriggerActions.cls
@@ -25,18 +25,19 @@ public inherited sharing class UserTriggerActions {
         update changedContacts;
     }
 
-    public static void createDeleteContactsForLibrarians(List<User> newusers, List<User> oldusers) {
+    public static void createDeleteContactsForLibrarians(List<User> newusers, Map<Id,User> oldusers) {
+        Profile librarianProfile = [SELECT Id FROM Profile WHERE Name='Librarian'];
         List<User> active = new List<User>();
         List<User> inactive = new List<User>();
 
         for (User u : newusers) {
-            if (u.IsActive) {
-                //todo: check if old is inactive
-                active.add(u);
-            }
-            else {
-                //todo: check if old is active
-                inactive.add(u);
+            if (u.ProfileId == librarianProfile.Id) {
+                if (u.IsActive && !oldusers.get(u.Id).IsActive) {
+                    active.add(u);
+                }
+                else if (!u.IsActive && oldusers.get(u.Id).IsActive) {
+                    inactive.add(u);
+                }
             }
         }
 
@@ -45,8 +46,6 @@ public inherited sharing class UserTriggerActions {
     }
 
     private static void deleteContactsForLibrarians(List<User> users) {
-        RecordType librarianRecordType = [SELECT Id FROM RecordType WHERE SobjectType='Contact' AND Name='Librarian'];
-        List<Contact> libContacts = [SELECT Id FROM Contact WHERE RecordTypeId = :librarianRecordType.Id];
-        //delete
+        System.enqueueJob(new LibrarianContactDeleterQueueable(users));
     }
 }

--- a/force-app/main/default/triggers/UserTrigger.trigger
+++ b/force-app/main/default/triggers/UserTrigger.trigger
@@ -3,7 +3,7 @@ trigger UserTrigger on User (after insert, after update) {
         UserTriggerActions.createContactsForLibrarians(Trigger.new);
     }
     if (Trigger.isAfter && Trigger.isUpdate) {
+        UserTriggerActions.createDeleteContactsForLibrarians(Trigger.new, Trigger.oldMap);
         UserTriggerActions.updateContactsForLibrarians(Trigger.new);
-    //    UserTriggerActions.createDeleteContactsForLibrarians(Trigger.new, Trigger.oldMap);
     }
 }


### PR DESCRIPTION
This uses a queueable to get around the MIXED_DML_OPERATION exception that occurs when it deletes the contacts.